### PR TITLE
delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf


### PR DESCRIPTION
Per concern at https://github.com/RaRe-Technologies/gensim/issues/2819#issuecomment-626416548 , detailed at https://stackoverflow.com/questions/61720528/simple-git-clone-mangles-many-files-with-phantom-un-resettable-modified-state?noredirect=1#comment109174230_61720528 , this new git config setting is causing problems on Linux & MacOS, at least. 